### PR TITLE
Ensure names are linked in messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.0.0'
+
 gem 'dotenv'
 gem 'sinatra'
 gem 'httparty'

--- a/tickbot.rb
+++ b/tickbot.rb
@@ -35,6 +35,7 @@ def slack_message(channel, text)
   url = "https://slack.com/api/chat.postMessage"
   params = { :token => ENV["SLACK_TOKEN"],
              :text => text,
+             :link_names => 1,
              :channel => channel,
              :username => "tickbot",
              :icon_url => "http://i.imgur.com/46JvWOZ.png" }


### PR DESCRIPTION
Slack's [API docs for `chat.postMessage`](https://api.slack.com/methods/chat.postMessage) state that the default for `link_names` is `1`, so I'm not sure why this is required, but it is. ¯_(ツ)_/¯

This PR also includes a commit pushed to Heroku but not yet to `barryf/tickbot` (98afc51).
